### PR TITLE
Harden for mutation testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ python:
   - '3.4'
   - '3.5'
   - '3.6'
+  - '3.7'
+  - 'pypy3.5'
   - 'pypy'
-  - 'pypy-5.3.1'
 install: pip install --upgrade --requirement dev-requirements.txt
 script:
   - isort --quiet --diff --recursive

--- a/streamcat/core.py
+++ b/streamcat/core.py
@@ -1,12 +1,10 @@
 import io
 
-DEFAULT_CHUNK_SIZE = 1024 * 1024
-
 
 class Stream(io.RawIOBase):
     def __init__(self, iterator):
         self.iterator = iterator
-        self.data = b''
+        self.data = b""
 
     def readable(self):
         return True
@@ -20,16 +18,11 @@ class Stream(io.RawIOBase):
     def read(self, size=-1):
         if size == -1:
             return self.readall()
-        chunks = []
-        data_length = len(self.data)
-        if data_length < size:
+        if len(self.data) < size:
             try:
-                chunk = next(self.iterator)
-                chunks.append(chunk)
-                data_length += len(chunk)
+                self.data += next(self.iterator)
             except StopIteration:
                 pass
-        self.data += b''.join(chunks)
         (result, self.data) = (self.data[:size], self.data[size:])
         return result
 
@@ -40,15 +33,15 @@ class Stream(io.RawIOBase):
         return data_length
 
     def readall(self):
-        return b''.join(self.iterator)
+        return b"".join(self.iterator)
 
 
 def iterator_to_stream(iterator):
     return Stream(iterator)
 
 
-def stream_to_iterator(file, decoder, chunk_size=DEFAULT_CHUNK_SIZE):
-    data = ''
+def stream_to_iterator(file, decoder, chunk_size):
+    data = ""
     while True:
         chunk = file.read(chunk_size).decode()
         data += chunk


### PR DESCRIPTION
The implementation and the tests were hardened so that Mutmut doesn't find any mutant that passes the tests.

The default chunk size was removed so that it can't be mutated.  It's OK since it was probably unnecessary (the user should decide what chunk size to use).

The code was also reformatted with Black although that's not checked in CI yet (it didn't change much).